### PR TITLE
Workontags

### DIFF
--- a/src/components/DBSearchResults.vue
+++ b/src/components/DBSearchResults.vue
@@ -162,10 +162,10 @@
           <hr>
 
           <h3 class="mt-3 mb-2 fs-5">Writer(s)</h3>
-          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Writer").length'>{{getCrewMember(topStructure(result).crew, "Writer")}} (Writer)</p>
-          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Screenplay").length'>{{getCrewMember(topStructure(result).crew, "Screenplay")}} (Screenplay)</p>
-          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Story").length'>{{getCrewMember(topStructure(result).crew, "Story")}} (Story)</p>
-          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Novel").length'>{{getCrewMember(topStructure(result).crew, "Novel")}} (Novel)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Writer")'>{{getCrewMember(topStructure(result).crew, "Writer")}} (Writer)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Screenplay")'>{{getCrewMember(topStructure(result).crew, "Screenplay")}} (Screenplay)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Story")'>{{getCrewMember(topStructure(result).crew, "Story")}} (Story)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Novel")'>{{getCrewMember(topStructure(result).crew, "Novel")}} (Novel)</p>
 
           <hr>
 
@@ -192,7 +192,7 @@
           <hr>
 
           <h3 class="mt-3 mb-2 fs-5">Tags</h3>
-          <p class="m-3">{{turnArrayIntoList(mostRecentRating(result).tags, "title")}}</p>
+          <p class="m-3">{{turnArrayIntoList(topStructure(result).tags, "title")}}</p>
 
           <hr v-if="turnArrayIntoList(result.awards?.oscarWins).length || turnArrayIntoList(result.awards?.oscarNoms).length">
 
@@ -210,6 +210,7 @@
             <span v-if="rating.medium && rating.date">on</span>
             <span v-else-if="rating.date">On</span>
             {{formattedDate(rating.date)}}
+            <span style="font-size: 12px; color: rgb(167, 167, 167);" v-if="rating.tags">&nbsp;&nbsp;{{ turnArrayIntoList(rating.tags, "title") }}</span>
           </p>
         </div>
       </li>

--- a/src/components/DBSearchResults.vue
+++ b/src/components/DBSearchResults.vue
@@ -162,7 +162,10 @@
           <hr>
 
           <h3 class="mt-3 mb-2 fs-5">Writer(s)</h3>
-          <p class="m-3">{{getCrewMember(topStructure(result).crew, "Writer")}}</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Writer").length'>{{getCrewMember(topStructure(result).crew, "Writer")}} (Writer)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Screenplay").length'>{{getCrewMember(topStructure(result).crew, "Screenplay")}} (Screenplay)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Story").length'>{{getCrewMember(topStructure(result).crew, "Story")}} (Story)</p>
+          <p class="m-3" v-if='getCrewMember(topStructure(result).crew, "Novel").length'>{{getCrewMember(topStructure(result).crew, "Novel")}} (Novel)</p>
 
           <hr>
 

--- a/src/components/DBSearchResults.vue
+++ b/src/components/DBSearchResults.vue
@@ -189,10 +189,10 @@
           <h3 class="mt-3 mb-2 fs-5">Cinematographer(s)</h3>
           <p class="m-3">{{getCrewMember(topStructure(result).crew, "Photo")}}</p>
 
-          <hr>
+          <hr v-if='turnArrayIntoList(topStructure(result).tags, "title")'>
 
-          <h3 class="mt-3 mb-2 fs-5">Tags</h3>
-          <p class="m-3">{{turnArrayIntoList(topStructure(result).tags, "title")}}</p>
+          <h3 class="mt-3 mb-2 fs-5" v-if='turnArrayIntoList(topStructure(result).tags, "title")'>Tags</h3>
+          <p class="m-3" v-if='turnArrayIntoList(topStructure(result).tags, "title")'>{{turnArrayIntoList(topStructure(result).tags, "title")}}</p>
 
           <hr v-if="turnArrayIntoList(result.awards?.oscarWins).length || turnArrayIntoList(result.awards?.oscarNoms).length">
 
@@ -210,7 +210,7 @@
             <span v-if="rating.medium && rating.date">on</span>
             <span v-else-if="rating.date">On</span>
             {{formattedDate(rating.date)}}
-            <span style="font-size: 12px; color: rgb(167, 167, 167);" v-if="rating.tags">&nbsp;&nbsp;{{ turnArrayIntoList(rating.tags, "title") }}</span>
+            <span class="ratings-tags" v-if="rating.tags">{{ turnArrayIntoList(rating.tags, "title") }}</span>
           </p>
         </div>
       </li>
@@ -461,24 +461,23 @@ export default {
     },
     tagSearch (tags) {
       return this.allMediaAsArray.filter((entry) => {
-        const ratings = entry.ratings;
-        const ratingTags = ratings.reduce((acc, rating) => {
-          if (rating.tags) {
-            Object.values(rating.tags).forEach(tag => {
-              if (tag.title) {
-                acc.push(tag.title.toLowerCase());
-              }
-            });
-          }
-          return acc;
-        }, []);
-
-        let allTags = ratingTags;
-        
+        let allTags = [];
+        if (!this.currentLogIsTVLog) {
+          let allTags = entry.ratings.reduce((acc, rating) => {
+            if (rating.tags) {
+              Object.values(rating.tags).forEach(tag => {
+                if (tag.title) {
+                  acc.push(tag.title.toLowerCase());
+                }
+              });
+            }
+            return acc;
+          }, []);
+        }
         if (this.topStructure(entry).tags) {
           const movieTags = this.topStructure(entry).tags;
           const tagNames = movieTags.map((movieTag) => movieTag.title.toLowerCase());
-          allTags = ratingTags.concat(tagNames);
+          allTags = allTags.concat(tagNames);
         }
 
         return tags.every((tag) => allTags.includes(tag));
@@ -933,6 +932,12 @@ export default {
             span {
               white-space: nowrap;
             }
+          }
+
+          .ratings-tags {
+            font-size: 0.75rem;
+            color: #a7a7a7;
+            padding-left: 3px;
           }
 
           .actors {


### PR DESCRIPTION
I made the suggested edit to my last request, and then made various inscrutable mistakes with GitHub but managed to pull out of it (I think) with this new _even better_ pull request. This includes some changes to the way tags are displayed in the detailed information for a movie. Previously, it was displaying the tags for the most recent viewing only. Now, under "Tags", it displays the tags which go with the film itself, and then displays the viewing tags next to the specific viewing in smaller, grey text. 

I formatted the viewing tags in a somewhat hacky way as I am not sure how to find/edit the CSS and make a style for it. I can only imagine the joyous the feeling of collaboration that is washing over you. 